### PR TITLE
Update VideoClip.py

### DIFF
--- a/moviepy/video/VideoClip.py
+++ b/moviepy/video/VideoClip.py
@@ -1103,7 +1103,9 @@ class TextClip(ImageClip):
                  print_cmd=False):
 
         if txt is not None:
-            if temptxt is None:
+          if txt == '':
+            raise Exception("Moviepy:Error! 'txt' can not be an empty string '' ")
+          elif temptxt is None:
                 temptxt_fd, temptxt = tempfile.mkstemp(suffix='.txt')
                 try:  # only in Python3 will this work
                     os.write(temptxt_fd, bytes(txt, 'UTF8'))


### PR DESCRIPTION
After installing MoviePy and using the example code of TextClip. I encountered an error similar to the following: 

```
During handling of the above exception, another exception occurred:

OSError                                   Traceback (most recent call last)
<ipython-input-4-bded32fb6bbb> in <module>()
      1 from moviepy.editor import *
      2 
----> 3 test_txtclip = TextClip('') #ground truth

/home/nachwa/anaconda3/lib/python3.6/site-packages/moviepy/video/VideoClip.py in __init__(self, txt, filename, size, color, bg_color, fontsize, font, stroke_color, stroke_width, method, kerning, align, interline, tempfilename, temptxt, transparent, remove_temp, print_cmd)
   1227                     "path to the ImageMagick binary in file conf.py, or."
   1228                     "that the path you specified is incorrect" ))
-> 1229             raise IOError(error)
   1230 
   1231         ImageClip.__init__(self, tempfilename, transparent=transparent)

OSError: MoviePy Error: creation of None failed because of the following error:

convert: no images defined `PNG32:/tmp/tmp6sc1qmxs.png' @ error/convert.c/ConvertImageCommand/3275.
.

.This error can be due to the fact that ImageMagick is not installed on your computer, or (for Windows users) that you didn't specify the path to the ImageMagick binary in file conf.py, or.that the path you specified is incorrect
```
Even I am using Linux and have ImageMagick already installed with python 3.6. 
The error message is not clear, after going through the code. I figure out that the error is due to the fact that I was passing an empty text to the example code. 

Therefore, I suggest the following edit in TextClip class:

+          if txt == '':
+            raise Exception("Moviepy:Error! 'txt' can not be an empty string '' ")
